### PR TITLE
Inherit shared pkgdown theming from animovementtemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,5 +34,5 @@ Suggests:
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
-Config/Needs/website: rmarkdown
+Config/Needs/website: animovement/animovementtemplate
 Config/roxygen2/version: 8.0.0

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,31 +2,11 @@ url: http://animovement.dev/aniframe/
 home:
   title: "aniframe – An R package providing core data structures for movement data"
 
-authors:
-  - name: "Mikkel Roald‑Arbøl"
-    href: "https://roald-arboel.com"
-
+# Shared navbar (incl. the animovement dropdown + Zulip), theme, and author
+# details are inherited from animovementtemplate.
 template:
   bootstrap: 5
-  light-switch: true
-
-navbar:
-  structure:
-    left:
-      - intro
-      - reference
-      - articles
-      - news
-    right:
-      - search
-      - github
-      - zulip
-      - lightswitch
-  components:
-    zulip:
-      icon: fa-comments
-      href: https://animovement.zulipchat.com
-      aria-label: Chat on Zulip
+  package: animovementtemplate
 
 articles:
   - title: "Get started"


### PR DESCRIPTION
## Summary

Brings aniframe's pkgdown site in line with `anivis` and `anicheck` by inheriting the shared theming from the `animovementtemplate` package instead of maintaining a bespoke config.

- `_pkgdown.yml`: replaced the package-local `template`, `navbar`, and `authors` blocks with `template.package: animovementtemplate`. The navbar (including the animovement ecosystem dropdown and the Zulip link), the light-switch theme, and the author details are now inherited from the template package, so they live in one place across the ecosystem. The `url`, home title, `articles`, and `reference` sections remain package-specific.
- `DESCRIPTION`: changed `Config/Needs/website` from `rmarkdown` to `animovement/animovementtemplate` so the template package is installed when the site is built.

The existing pkgdown workflow already uses `needs: website` with `local::.`, so the GitHub-remote template installs without any workflow change.

## Notes

- The old navbar listed an `intro` item, but there is no getting-started page backing it (all vignettes live under `vignettes/articles/`), so dropping it has no effect on the rendered site and matches the shared template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)